### PR TITLE
Introduced new Search endpoint

### DIFF
--- a/src/Limbo.Integrations.Skyfish/Endpoints/SkyfishSearchEndpoint.cs
+++ b/src/Limbo.Integrations.Skyfish/Endpoints/SkyfishSearchEndpoint.cs
@@ -1,0 +1,22 @@
+﻿using Limbo.Integrations.Skyfish.Options.Videos;
+using Limbo.Integrations.Skyfish.Responses.Search;
+
+namespace Limbo.Integrations.Skyfish.Endpoints {
+    
+    public class SkyfishSearchEndpoint {
+
+        public SkyfishHttpService Service { get; }
+
+        public SkyfishSearchRawEndpoint Raw => Service.Client.Search;
+
+        public SkyfishSearchEndpoint(SkyfishHttpService service) {
+            Service = service;
+        }
+
+        public SkyfishSearchResponse Search(SkyfishSearchOptions options) {
+            return new(Raw.Search(options));
+        }
+
+    }
+
+}

--- a/src/Limbo.Integrations.Skyfish/Endpoints/SkyfishSearchRawEndpoint.cs
+++ b/src/Limbo.Integrations.Skyfish/Endpoints/SkyfishSearchRawEndpoint.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Limbo.Integrations.Skyfish.Http;
+using Limbo.Integrations.Skyfish.Options.Videos;
+using Skybrud.Essentials.Http;
+
+namespace Limbo.Integrations.Skyfish.Endpoints {
+    
+    public class SkyfishSearchRawEndpoint {
+
+        public SkyfishHttpClient Client { get; }
+
+        public SkyfishSearchRawEndpoint(SkyfishHttpClient client) {
+            Client = client;
+        }
+
+        #region Member methods
+
+        public IHttpResponse Search(SkyfishSearchOptions options) {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            return Client.GetResponse(options);
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Limbo.Integrations.Skyfish/Http/SkyfishHttpClient.cs
+++ b/src/Limbo.Integrations.Skyfish/Http/SkyfishHttpClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Caching;
 using System.Threading;
+using Limbo.Integrations.Skyfish.Endpoints;
 using Limbo.Integrations.Skyfish.Models;
 using Newtonsoft.Json.Linq;
 using Skybrud.Essentials.Http;
@@ -22,15 +23,22 @@ namespace Limbo.Integrations.Skyfish.Http {
 
         public string Password { get; }
 
+        public SkyfishSearchRawEndpoint Search { get; }
+
         private readonly string _token;
 
-        public SkyfishHttpClient() { }
+        public SkyfishHttpClient() {
+            Search = new SkyfishSearchRawEndpoint(this);
+        }
 
         public SkyfishHttpClient(string apikey, string secretkey, string username, string password) {
+            
             ApiKey = apikey;
             SecretKey = secretkey;
             Username = username;
             Password = password;
+            
+            Search = new SkyfishSearchRawEndpoint(this);
 
             _token = GetToken();
         }

--- a/src/Limbo.Integrations.Skyfish/Models/Media/SkyfishMediaItem.cs
+++ b/src/Limbo.Integrations.Skyfish/Models/Media/SkyfishMediaItem.cs
@@ -1,0 +1,56 @@
+﻿using Newtonsoft.Json.Linq;
+using Skybrud.Essentials.Json;
+using Skybrud.Essentials.Json.Extensions;
+
+namespace Limbo.Integrations.Skyfish.Models.Media {
+    
+    public class SkyfishMediaItem : JsonObjectBase {
+
+        #region Properties
+
+        public string[] Keywords { get; }
+
+        public int Height { get; }
+
+        public int Width { get; }
+
+        public int UniqueMediaId { get; }
+
+        public string Title { get; }
+
+        public string Description { get; }
+
+        public string ThumbnailUrl { get; }
+
+        public string ThumbnailUrlSsl { get; }
+
+        public string FileName { get; }
+
+        public string FileMimeType { get; }
+
+        public long FileDiskSize { get; }
+
+        #endregion
+        
+        protected SkyfishMediaItem(JObject json) : base(json) {
+            Keywords = json.GetStringArray("keywords");
+            Height = json.GetInt32("height");
+            Width = json.GetInt32("width");
+            UniqueMediaId = json.GetInt32("unique_media_id");
+            Title = json.GetString("title");
+            Description = json.GetString("description");
+            ThumbnailUrl = json.GetString("thumbnail_url");
+            ThumbnailUrlSsl = json.GetString("thumbnail_url_ssl");
+            FileName = json.GetString("filename");
+            FileDiskSize = json.GetInt32("file_disksize");
+            FileMimeType = json.GetString("file_mimetype");
+        }
+
+        public static SkyfishMediaItem Parse(JObject json) {
+            return json == null ? null : new SkyfishMediaItem(json);
+
+        }
+
+    }
+
+}

--- a/src/Limbo.Integrations.Skyfish/Models/Media/SkyfishMediaType.cs
+++ b/src/Limbo.Integrations.Skyfish/Models/Media/SkyfishMediaType.cs
@@ -1,0 +1,12 @@
+﻿namespace Limbo.Integrations.Skyfish.Models.Media {
+    
+    public enum SkyfishMediaType {
+        Unrecognized = -1,
+        Unspecified = 0,
+        Image,
+        Vector,
+        Video,
+        Generic,
+    }
+
+}

--- a/src/Limbo.Integrations.Skyfish/Models/Search/SkyfishSearchResult.cs
+++ b/src/Limbo.Integrations.Skyfish/Models/Search/SkyfishSearchResult.cs
@@ -1,0 +1,25 @@
+﻿using Limbo.Integrations.Skyfish.Models.Media;
+using Newtonsoft.Json.Linq;
+using Skybrud.Essentials.Json;
+using Skybrud.Essentials.Json.Extensions;
+
+namespace Limbo.Integrations.Skyfish.Models.Search {
+    
+    public class SkyfishSearchResult : JsonObjectBase {
+
+        public int Hits { get; }
+
+        public SkyfishMediaItem[] Media { get; }
+        
+        private SkyfishSearchResult(JObject json) : base(json) {
+            Hits = json.GetInt32("response.hits");
+            Media = json.GetArrayItems("response.media", SkyfishMediaItem.Parse);
+        }
+
+        public static SkyfishSearchResult Parse(JObject json) {
+            return json == null ? null : new SkyfishSearchResult(json);
+        }
+
+    }
+
+}

--- a/src/Limbo.Integrations.Skyfish/Options/Search/SkyfishSearchOptions.cs
+++ b/src/Limbo.Integrations.Skyfish/Options/Search/SkyfishSearchOptions.cs
@@ -52,7 +52,8 @@ namespace Limbo.Integrations.Skyfish.Options.Videos {
                 "description",
                 "thumbnail_url",
                 "thumbnail_url_ssl",
-                "filename+file_disksize",
+                "filename",
+                "file_disksize",
                 "file_mimetype"
             };
 

--- a/src/Limbo.Integrations.Skyfish/Options/Search/SkyfishSearchOptions.cs
+++ b/src/Limbo.Integrations.Skyfish/Options/Search/SkyfishSearchOptions.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Limbo.Integrations.Skyfish.Models.Media;
+using Skybrud.Essentials.Http;
+using Skybrud.Essentials.Http.Collections;
+using Skybrud.Essentials.Http.Options;
+using Skybrud.Essentials.Strings.Extensions;
+
+namespace Limbo.Integrations.Skyfish.Options.Videos {
+    
+    /// <summary>
+    /// Class with options for getting a list of videos.
+    /// </summary>
+    public class SkyfishSearchOptions : IHttpRequestOptions {
+
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the ID of a specific media to be returned.
+        /// </summary>
+        public int MediaId { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the unique ID of a specific media to be returned.
+        /// </summary>
+        public int UniqueMediaId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of values (field) to be returned for each media.
+        /// </summary>
+        public List<string> ReturnValues { get; set; }
+
+        /// <summary>
+        /// Gets or sets the media types to be returned.
+        /// </summary>
+        public List<SkyfishMediaType> MediaTypes { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance with default options.
+        /// </summary>
+        public SkyfishSearchOptions() {
+            
+            ReturnValues = new List<string> {
+                "unique_media_id",
+                "height",
+                "width",
+                "title",
+                "description",
+                "thumbnail_url",
+                "thumbnail_url_ssl",
+                "filename+file_disksize",
+                "file_mimetype"
+            };
+
+            MediaTypes = new List<SkyfishMediaType>();
+
+        }
+
+        #endregion
+
+        #region Member methods
+
+        /// <inheritdoc />
+        public IHttpRequest GetRequest() {
+            
+            // Initialize the query string
+            IHttpQueryString query = new HttpQueryString();
+
+            // Append optional parameters if specified
+            if (MediaId > 0) query.Add("media_id", MediaId);
+            if (UniqueMediaId > 0) query.Add("unique_media_id", UniqueMediaId);
+            if (ReturnValues != null && ReturnValues.Count > 0) query.Add("return_values", string.Join("+", query));
+            if (MediaTypes != null && MediaTypes.Count > 0) query.Add("media_type", string.Join("+", from type in MediaTypes select type.ToUnderscore()));
+
+            // Initialize a new GET request
+            return HttpRequest.Get("/search", query);
+
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Limbo.Integrations.Skyfish/Responses/Search/SkyfishSearchResponse.cs
+++ b/src/Limbo.Integrations.Skyfish/Responses/Search/SkyfishSearchResponse.cs
@@ -1,0 +1,14 @@
+﻿using Skybrud.Essentials.Http;
+using Limbo.Integrations.Skyfish.Models.Search;
+
+namespace Limbo.Integrations.Skyfish.Responses.Search {
+
+    public class SkyfishSearchResponse : SkyfishResponse<SkyfishSearchResult> {
+
+        public SkyfishSearchResponse(IHttpResponse response) : base(response) {
+            Body = ParseJsonObject(response.Body, SkyfishSearchResult.Parse);
+        }
+
+    }
+
+}

--- a/src/Limbo.Integrations.Skyfish/Responses/SkyfishResponse.cs
+++ b/src/Limbo.Integrations.Skyfish/Responses/SkyfishResponse.cs
@@ -1,0 +1,42 @@
+﻿using System.Net;
+using Skybrud.Essentials.Http;
+using Limbo.Integrations.Skyfish.Exceptions;
+
+namespace Limbo.Integrations.Skyfish.Responses {
+
+    /// <summary>
+    /// Class representing a response from the Skyfish API.
+    /// </summary>
+    public class SkyfishResponse : HttpResponseBase {
+
+        /// <summary>
+        /// Initializes a new instance based on the specified <paramref name="response"/>.
+        /// </summary>
+        /// <param name="response">The instance of <see cref="IHttpResponse"/> representing the raw response.</param>
+        public SkyfishResponse(IHttpResponse response) : base(response) {
+            if (response.StatusCode == HttpStatusCode.OK) return;
+            if (response.StatusCode == HttpStatusCode.Created) return;
+            throw new SkyfishHttpException(response);
+        }
+
+    }
+
+    /// <summary>
+    /// Class representing a response from the Skyfish API.
+    /// </summary>
+    public class SkyfishResponse<T> : SkyfishResponse {
+
+        /// <summary>
+        /// /// Gets the body of the response.
+        /// </summary>
+        public T Body { get; protected set; }
+
+        /// <summary>
+        /// Initializes a new instance based on the specified <paramref name="response"/>.
+        /// </summary>
+        /// <param name="response">The instance of <see cref="IHttpResponse"/> representing the raw response.</param>
+        public SkyfishResponse(IHttpResponse response) : base(response) { }
+
+    }
+
+}

--- a/src/Limbo.Integrations.Skyfish/SkyfishHttpHelper.cs
+++ b/src/Limbo.Integrations.Skyfish/SkyfishHttpHelper.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Linq;
+using Limbo.Integrations.Skyfish.Models.Media;
+using Limbo.Integrations.Skyfish.Options.Videos;
+using Limbo.Integrations.Skyfish.Responses.Search;
+
+namespace Limbo.Integrations.Skyfish {
+    
+    public class SkyfishHttpHelper {
+
+        #region Properties
+
+        public SkyfishHttpService Service { get; }
+
+        #endregion
+
+        #region Constructors
+
+        public SkyfishHttpHelper(SkyfishHttpService service) {
+            Service = service ?? throw new ArgumentNullException(nameof(service));
+        }
+
+        #endregion
+
+        #region Member methods
+
+        public SkyfishMediaItem GetVideoByMediaId(int mediaId) {
+
+            // Search for the video in the via the Search API
+            SkyfishSearchResponse response = Service.Search.Search(new SkyfishSearchOptions {
+                MediaId = mediaId
+            });
+
+
+            return response.Body.Media.FirstOrDefault();
+
+        }
+
+        public SkyfishMediaItem GetVideoByUniqueMediaId(int uniqueMediaId) {
+
+            // Search for the video in the via the Search API
+            SkyfishSearchResponse response = Service.Search.Search(new SkyfishSearchOptions {
+                UniqueMediaId = uniqueMediaId
+            });
+
+
+            return response.Body.Media.FirstOrDefault();
+
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Limbo.Integrations.Skyfish/SkyfishHttpService.cs
+++ b/src/Limbo.Integrations.Skyfish/SkyfishHttpService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Limbo.Integrations.Skyfish.Endpoints;
 using Limbo.Integrations.Skyfish.Http;
 using Limbo.Integrations.Skyfish.Models;
 
@@ -6,8 +7,11 @@ namespace Limbo.Integrations.Skyfish {
     public class SkyfishHttpService {
         public SkyfishHttpClient Client { get; }
 
+        public SkyfishSearchEndpoint Search { get; }
+
         private SkyfishHttpService(SkyfishHttpClient client) {
             Client = client;
+            Search = new SkyfishSearchEndpoint(this);
         }
 
         public SkyfishVideo GetVideo(int id) {


### PR DESCRIPTION
Hi @jemayn 

This PR introduces a new search endpoint, since that is what we're currently using for getting the videos (but via other methods).

The `Search` method creates a uniform approach to searching for media, which should then also help cutting down on duplicate code. It could be used as:

```csharp
// Search for the video in the via the Search API
SkyfishSearchResponse response = Service.Search.Search(new SkyfishSearchOptions {
    MediaId = mediaId
});


// Get the first media/video of the response (if there are any)
SkyfishMediaItem video = response.Body.Media.FirstOrDefault();
```

Or:

```csharp
// Search for the video in the via the Search API
SkyfishSearchResponse response = Service.Search.Search(new SkyfishSearchOptions {
    UniqueMediaId = uniqueMediaId
});


// Get the first media/video of the response (if there are any)
SkyfishMediaItem video = response.Body.Media.FirstOrDefault();
```


I've also introduced a new `SkyfishHttpHelper` class. I'm haven't really done this for the other integrations, as I think the "interpretation" of the API should be handled by whoever or whatever is using our integration API. But since we now have the underlying search endpoint, the helper class could for instance have these two methods:

```csharp
public SkyfishMediaItem GetVideoByMediaId(int mediaId) {

    // Search for the video in the via the Search API
    SkyfishSearchResponse response = Service.Search.Search(new SkyfishSearchOptions {
        MediaId = mediaId
    });


    return response.Body.Media.FirstOrDefault();

}

public SkyfishMediaItem GetVideoByUniqueMediaId(int uniqueMediaId) {

    // Search for the video in the via the Search API
    SkyfishSearchResponse response = Service.Search.Search(new SkyfishSearchOptions {
        UniqueMediaId = uniqueMediaId
    });


    return response.Body.Media.FirstOrDefault();

}
```

In theory we could also add a `GetThumbnailUrl` (or one for each type of ID) to the helper class, but now the Umbraco package might as well just call `helper.GetVideoByMediaId(mediaId).ThumbnailUrlSsl` or `helper.GetVideoByUniqueMediaId(uniqueMediaId).ThumbnailUrlSsl`.

The logic around saving the authentication token to the memory cache could also be moved here from `SkyfishHttpClient`, but keep the actual calls to the API in `SkyfishHttpClient`. This creates a layer of separation, which should hopefully make the package easier to maintain and use.

For now, I'm creating this PR as a draft. Partly because I haven't tested my code against the API, and partly because we can use it for discussing the right away to proceed.